### PR TITLE
*Fix: Auto scroll always starts, even the option is not defined

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -220,9 +220,9 @@ function Swipe(container, options) {
   var interval;
 
   function begin() {
-
-    interval = setTimeout(next, delay);
-
+    if(delay > 0) {
+      interval = setTimeout(next, delay);
+    }
   }
 
   function stop() {


### PR DESCRIPTION
Only enable auto scrolling when the 'auto' option value is higher than 0
