### PR TITLE
Return Swipe instance in factory to fix CommonJS/AMD compatibility

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -589,4 +589,5 @@ function Swipe(container, options) {
       }
     })( window.jQuery || window.Zepto )
   }
+  return Swipe;
 }));


### PR DESCRIPTION
Hi nickleefly,

I'm using your fork and getting an empty object while importing the lib.

After some research it cames out that it is simple because the factory doesn't return anything.

Hope it helps.

Gabriel.
