### PR TITLE
Return Swipe instance in factory to fix CommonJS/AMD compatibility

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -575,7 +575,7 @@ function Swipe(container, options) {
 
 (function (factory) {
   if(typeof module === "object" && typeof module.exports === "object") {
-    factory(require("jquery"), window, document);
+    module.exports = factory(require("jquery"), window, document);
   } else {
     factory(jQuery, window, document);
   }
@@ -589,4 +589,5 @@ function Swipe(container, options) {
       }
     })( window.jQuery || window.Zepto )
   }
+  return Swipe;
 }));


### PR DESCRIPTION
Hi nickleefly,

I'm using your fork and getting an empty object while importing the lib.

After some research it cames out that it is simple because the factory doesn't return anything.

Hope it helps.

Gabriel.
